### PR TITLE
Closes #1: bug fix for total time logged in Task

### DIFF
--- a/components/TaskCard.tsx
+++ b/components/TaskCard.tsx
@@ -17,7 +17,7 @@ const TaskCard = ({ task, navigation }: TaskProps) => {
 
     useEffect(() => {
         getTotalTimelogForTask(task.id).then(setTotalTime)
-    }, [])
+    })
 
     const handleEdit = () => {
         navigation.navigate('EditTask', { task })


### PR DESCRIPTION
Remove dependency array from useEffect. This allows the Task Card to refresh when there is a new timelog.
